### PR TITLE
bugfix: changes the kill signal from KILL to QUIT

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -20,7 +20,7 @@ namespace :index do
     desc "Stop the worker"
     task :stop => :environment do
       if worker_running?
-        sh "kill -9 #{worker_pid} && rm -f #{worker_pid_file}; true"
+        sh "kill -QUIT #{worker_pid} && rm -f #{worker_pid_file}; true"
       else
         puts "Worker was not running"
       end


### PR DESCRIPTION
bugfix: uses the documented way of shutting down the worker and allows the web application to stay in sync, otherwise the web application would still show an active worker, even though it was just killed
