### PR TITLE
allow users to configure Add/Optimize Solr call

### DIFF
--- a/lib/infopark/ses/indexer.rb
+++ b/lib/infopark/ses/indexer.rb
@@ -2,6 +2,7 @@ module Infopark
   module SES
 
     class Indexer
+      attr_accessor :indexed_docs
 
       def self.queue
         "index_#{RailsConnector::InfoparkBase.instance_name}"
@@ -74,10 +75,13 @@ module Infopark
           end
         end
 
-        @indexed_docs ||= 0
-        @indexed_docs += 1
+        self.indexed_docs += 1
 
         optimize if trigger_optimize?
+      end
+
+      def indexed_docs
+        @indexed_docs || 0
       end
 
       def optimize
@@ -122,7 +126,7 @@ module Infopark
       end
 
       def trigger_optimize?
-        @indexed_docs > 2
+        self.indexed_docs > 2
       end
 
       def self.log(severity, msg)

--- a/lib/infopark/ses/version.rb
+++ b/lib/infopark/ses/version.rb
@@ -1,5 +1,5 @@
 module Infopark
   module SES
-    VERSION = "6.9.0.1"
+    VERSION = "6.9.1"
   end
 end

--- a/test_app/Gemfile.lock
+++ b/test_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    infopark_ses (6.9.0.1)
+    infopark_ses (6.9.1)
       resque
       rsolr
 


### PR DESCRIPTION
The optimize call that is performed basically after every update is very time consuming when using the defaults.

To allow users to configure the ```add``` and ```optimize``` call, this pull request adds a possibility to pass options to Solr. Those options can be found [in the Solr Docs](http://wiki.apache.org/solr/UpdateXmlMessages#Optional_attributes_for_.22commit.22_and_.22optimize.22).

Options may be set like this:

```
Infopark::SES::Indexer.solr_options = {
  add: {
    commitWithin: 5000,
  },
  optimize: {
    expungeDeletes: true,
}
```

Also, the trigger of an optimization may be overridden because it is now available as a dedicated method.
